### PR TITLE
Make updates more robust

### DIFF
--- a/include/helpers.php
+++ b/include/helpers.php
@@ -79,7 +79,7 @@ function create_tag_drop_trigger() {
  * Creates the MugShot face tag table with all data columns required for resizing.
  */
 function create_facetag_table() {
-    $configQuery = 'INSERT INTO ' . CONFIG_TABLE . ' (param,value,comment) VALUES ("MugShot","","MugShot configuration values");';
+    $configQuery = 'REPLACE INTO ' . CONFIG_TABLE . ' (param,value,comment) VALUES ("MugShot","","MugShot configuration values");';
 
     pwg_query($configQuery);
 


### PR DESCRIPTION
During update I ran into an issue 

```
<b>Warning</b>:  [mysql error 1062] Duplicate entry 'MugShot' for key 'PRIMARY'
INSERT INTO piwigo_config (param,value,comment) VALUES ("MugShot","","MugShot configuration values"); in <b>/var/www/virtual/x/html/include/dblayer/functions_mysqli.inc.php</b> on line <b>847</b><br />
```

I was able to solve it with this patch.

As the following query also works if the table already exists, this seems to be more robust.