### PR TITLE
#24 Reliable way to disable autocomplete

### DIFF
--- a/js/admin_mug.js
+++ b/js/admin_mug.js
@@ -292,6 +292,7 @@ var MugShot = {
 
   createTextBox: (function () {
     var mug = this.mugs[this.cfi].frame;
+    var form = document.createElement('form');
     var name = document.createElement('input');
     var tagName = mug.name;
     name.addEventListener('keyup', doneWithText);
@@ -301,9 +302,10 @@ var MugShot = {
     name.style.top = parseInt(mug.top) + parseInt(mug.height) + 'px';
     name.style.left = mug.el.style.left;
     name.style.width = mug.el.style.width;
-    name.autocomplete = false;
+    name.autocomplete = "off";
     name.type = "text";
-    document.getElementById(this.id2).append(name);
+    form.appendChild(name); 
+    document.getElementById(this.id2).append(form);
     this.mugs[this.cfi].name.el = name;
     this.mugs[this.cfi].frame.el.title = name.value;
   }),


### PR DESCRIPTION
Fixes autocomplete problem

Tested in Chrome 99 + Firefox 98

Based on  https://stackoverflow.com/questions/15738259/disabling-chrome-autofill

> Jan 2021: autocomplete="off" does work as expected now (tested on Chrome 88 macOS).
> For this to work be sure to have your input tag within a Form tag