### PR TITLE
Update main.inc.php - Issues #40 #41

### DIFF
--- a/main.inc.php
+++ b/main.inc.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: Mug Shot
-Version: 2.0.2
+Version: 2.0.3
 Description: Improved face tagging for Piwigo
 Plugin URI: http://piwigo.org/ext/extension_view.php?eid=910
 Author: ccraige90
@@ -27,7 +27,7 @@ define('MUGSHOT_ID',      basename(dirname(__FILE__)));
 define('MUGSHOT_PATH' ,   PHPWG_PLUGINS_PATH . MUGSHOT_ID . '/');
 define('MUGSHOT_ADMIN',   get_root_url() . 'admin.php?page=plugin-' . MUGSHOT_ID);
 define('MUGSHOT_BASE_URL',   get_root_url() . 'admin.php?page=plugin-' . MUGSHOT_ID);
-define('MUGSHOT_VERSION', '2.0.2');
+define('MUGSHOT_VERSION', '2.0.3');
 define('MUGSHOT_TABLE', '`face_tag_positions`');
 define('MUGSHOT_QUEUE_TABLE', '`face_tag_queue`');
 


### PR DESCRIPTION
When updating to version 2.0.3, the version number in main.inc.php was forgotten to be updated.
This change fixes the error message that version 2.0.3 is not compatible with Piwigo.